### PR TITLE
ruby2.5-many-others イメージの bundler バージョンを 2.1.4 に固定化

### DIFF
--- a/ruby2.5-many-others/Dockerfile
+++ b/ruby2.5-many-others/Dockerfile
@@ -43,5 +43,5 @@ CMD ["bash"]
 LABEL vendor     "Neogenia Ltd."
 LABEL maintainer "Wataru Maeda <w.maeda@neogenia.co.jp>"
 
-RUN gem install bundler
+RUN gem install bundler:2.1.4
 

--- a/ruby2.5-many-others/Dockerfile
+++ b/ruby2.5-many-others/Dockerfile
@@ -43,5 +43,6 @@ CMD ["bash"]
 LABEL vendor     "Neogenia Ltd."
 LABEL maintainer "Wataru Maeda <w.maeda@neogenia.co.jp>"
 
-RUN gem install bundler:2.1.4
+RUN gem install bundler:2.1.4 \
+ && gem uninstall bundler --version 2.2.28
 


### PR DESCRIPTION
ビルドして `2.5.9-1` というタグを付けて DockerHub にアップロード済みです。
@TomoProg レビューをお願いします