### PR TITLE
rubyのベースイメージを Ubuntu 22.04LTS ベースに更新

### DIFF
--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic-20190612
+FROM ubuntu:jammy-20221101
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get -y install \
 
 ############################################################
 # install ruby
-ARG RUBY_VERSION=2.6.0
+ARG RUBY_VERSION=3.1.2
 ARG BUILD_OPTS=""
 RUN curl -L http://ftp.ruby-lang.org/pub/ruby/${RUBY_VERSION%.*}/ruby-${RUBY_VERSION}.tar.xz | tar Jx \
  && (cd ruby-${RUBY_VERSION} && ./configure --disable-install-doc ${BUILD_OPTS} && make install ) \


### PR DESCRIPTION
[neogenia/rails-basic:3.1.3](https://hub.docker.com/layers/neogenia/rails-basic/3.1.3/images/sha256-433e3480eef72dc243f60e2be6ab5967a5e5770af5ce3fb0f83e9cd25f4c5799?context=explore) をビルドして dockerhub に push 済み。

利用するには docker バージョン 20.10 以降が必要。