### PR TITLE
add gpg-agent into mariadb-mroonga/Dockerfile

### DIFF
--- a/mariadb-mroonga/Dockerfile
+++ b/mariadb-mroonga/Dockerfile
@@ -11,6 +11,7 @@ RUN apt update \
 # install mecab tokenizer
 RUN apt update \
     && apt install -y software-properties-common \
+                      gpg-agent \
     && add-apt-repository -y universe \
     && add-apt-repository -y ppa:groonga/ppa \
     && apt update \


### PR DESCRIPTION
ビルドエラーが出たので `gpg-agent` を追加インストールするようにしました。
DockerHub にも push 済みです。
@TomoProg レビューをお願いします