### PR TITLE
Ruby 3.2 のためのベース更新

### DIFF
--- a/rails-basic/Dockerfile
+++ b/rails-basic/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=2.7.0
+ARG RUBY_VERSION=3.2.6
 FROM neogenia/ruby:$RUBY_VERSION
 
 # install dependency packages

--- a/rails-basic/Dockerfile
+++ b/rails-basic/Dockerfile
@@ -38,8 +38,7 @@ RUN curl -L 'https://dl.yarnpkg.com/debian/pubkey.gpg' | apt-key add - \
 # clean apt-get files
 RUN apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
-# update bundler 2.1.x because default-version is 1.17 in ruby 2.7
-RUN gem install bundler:2.1.4
+RUN gem install bundler:2.4.22
 
 # misc settings
 RUN usermod -u 1000 www-data

--- a/rails-basic/Dockerfile
+++ b/rails-basic/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -L -O https://moji.or.jp/wp-content/ipafont/IPAexfont/${FONT_FILE}.zip 
 # install node.js, yarn (for webpacker) and some packages
 RUN curl -L 'https://dl.yarnpkg.com/debian/pubkey.gpg' | apt-key add - \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
- && curl -L 'https://deb.nodesource.com/setup_20.x' | bash - \
+ && curl -L 'https://deb.nodesource.com/setup_22.x' | bash - \
  && apt-get install -y nodejs yarn \
  && yarn global add typescript
 

--- a/rails-basic/Dockerfile
+++ b/rails-basic/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
 RUN gem install bundler:2.4.22
 
-# misc settings
-RUN usermod -u 1000 www-data
-RUN usermod -s /bin/bash www-data
+## misc settings for Ubuntu 24.04
+RUN usermod -u 1001 ubuntu \
+ && usermod -u 1000 www-data \
+ && usermod -s /bin/bash www-data
 

--- a/rails-basic/Dockerfile
+++ b/rails-basic/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -L -O https://moji.or.jp/wp-content/ipafont/IPAexfont/${FONT_FILE}.zip 
 # install node.js, yarn (for webpacker) and some packages
 RUN curl -L 'https://dl.yarnpkg.com/debian/pubkey.gpg' | apt-key add - \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
- && curl -L 'https://deb.nodesource.com/setup_14.x' | bash - \
+ && curl -L 'https://deb.nodesource.com/setup_20.x' | bash - \
  && apt-get install -y nodejs yarn \
  && yarn global add typescript
 

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get -y install \
         libyaml-dev \
         libjemalloc-dev \
         zlib1g-dev \
+        rustc \
         curl \
         vim-tiny \
         locales \
@@ -20,7 +21,7 @@ RUN apt-get update && apt-get -y install \
 
 ############################################################
 # install ruby
-ARG RUBY_VERSION=3.1.2
+ARG RUBY_VERSION=3.2.0
 ARG BUILD_OPTS=""
 RUN curl -L http://ftp.ruby-lang.org/pub/ruby/${RUBY_VERSION%.*}/ruby-${RUBY_VERSION}.tar.xz | tar Jx \
  && (cd ruby-${RUBY_VERSION} && ./configure --disable-install-doc ${BUILD_OPTS} && make install ) \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy-20221101
+FROM ubuntu:noble-20250127
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
### コミット位置とコンテナイメージのビルドバージョンの関係
- commit id: 880569ac50d876f370398b7589292227f492b51c
  - [neogenia/rails-basic:3.2.6](https://hub.docker.com/repository/docker/neogenia/rails-basic/tags/3.2.6/sha256:e5520be063d022e4ac09a5114a5dc8b6daecc4d49cde5737016db2f2da0ecb1c)
- commit id: 88a6ac7945b0cd0f7f3ca809f0f21ff68c220dd7
  - [neogenia/rails-basic:3.2.7](https://hub.docker.com/repository/docker/neogenia/rails-basic/tags/3.2.7/sha256:b977be9f828fb006923552968183db352140c4a810765fd97ae4ea4ba451c30c)
  - [neogenia/rails-basic:3.3.7](https://hub.docker.com/repository/docker/neogenia/rails-basic/tags/3.3.7/sha256:e2aad18dfc2a258d926df5de2bc8d1e56eda2c0cf6e11f08d309701f4830f530)