### PR TITLE
[digital-addres-proxy]ブラウザキャッシュしてもらう設定を追加

### DIFF
--- a/digital-address-proxy/docker/src/index.php
+++ b/digital-address-proxy/docker/src/index.php
@@ -10,6 +10,8 @@ $API_BASE_URL = 'https://api.da.pf.japanpost.jp/api/v1';  // 本番用APIアド�
 header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: *');
 header('Access-Control-Allow-Headers: *');
+$max_age = 60 * 60 * 24 * 30; // 30日
+header("Cache-Control: max-age=$max_age");
 
 if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
     http_response_code(204);


### PR DESCRIPTION
レスポンスを30日ブラウザ側でキャッシュしてもらうヘッダを追加しました。

@lobin-z0x50 レビューをお願いします。

### エビデンス

2回目以降のレスポンスはディスクキャッシュから取得されるようになりました。

![image](https://github.com/user-attachments/assets/553edac9-0101-4266-ae2d-578b9402257a)
