### PR TITLE
credencials.json の指定方法説明、ロングシンタックスで書き直し

### DIFF
--- a/digital-address-proxy/README.md
+++ b/digital-address-proxy/README.md
@@ -37,22 +37,25 @@ docker build -f docker/Dockerfile -t neogenia/digital-address-proxy .
 
 ## 起動方法
 
-以下はdocker-composeを使った起動方法です。
+以下は docker-compose を使った起動方法です。
 
-次のような記載があるymlファイルを作成してください。
+`credentials.json` が（`docker-compose.yml` から見て） `./config/credentials.json` においてある場合、
+以下のように bindマウントを記述してください。
 
 ```yaml
+# docker-sompose.yml
+version: "3.3"
 services:
   digita_address_proxy:
     container_name: digital-address-proxy
-    image: neogenia/digital-address-proxy:latest
+    image: neogenia/digital-address-proxy:20250710
     ports:
       - "80:80"
     volumes:
-      - ${CREDENTIALS_FILE_PATH}:/var/www/resources/credentials.json
+      - type: bind
+        source: ./config/credentials.json  # ここに相対ファイルパスを書く
+        target: /var/credentials.json
+        read_only: true
     environment:
-      CREDENTIALS_FILE_PATH   : /var/www/resources/credentials.json
+      CREDENTIALS_FILE_PATH: /var/credentials.json
 ```
-
-`${CREDENTIALS_FILE_PATH}` は 事前準備で作成した`credentials.json` へのパスを、docker-compose.yml ファイルのあるディレクトリからの相対パスまたは絶対パスで指定してください。
-


### PR DESCRIPTION
neo-dockers サーバで実際に稼働させた構成を反映しました。
`credentials.json` のパスを書き間違えた時、ショートシンタックスだと空のディレクトリが root で作成されて困ったので、ロングシンタックスに修正しました。

参考: https://www.notion.so/neogenia-jp/1f51d26fb809804ba1f4f98d0a27ba43?source=copy_link#1f51d26fb80980679033f5dc5c0f3639