### PR TITLE
[digital-address-proxy]アクセスログのローテーションを実装

### DIFF
--- a/digital-address-proxy/docker/Dockerfile
+++ b/digital-address-proxy/docker/Dockerfile
@@ -3,3 +3,15 @@ FROM php:8.2-apache
 COPY ./src /var/www/html
 # rewriteモジュールを有効にする
 RUN a2enmod rewrite
+# リダイレクトを解除するため、既存のアクセスログファイルを削除して再作成
+RUN rm -f /var/log/apache2/access.log \
+    && rm -f /var/log/apache2/error.log \
+    && rm -f /var/log/apache2/other_vhosts_access.log \
+    && touch /var/log/apache2/access.log \
+    && touch /var/log/apache2/error.log \
+    && touch /var/log/apache2/other_vhosts_access.log \
+    && chmod a+w /var/log/apache2/access.log /var/log/apache2/error.log /var/log/apache2/other_vhosts_access.log
+
+# アクセスログの設定を上書きする
+COPY ./resources/etc/apache2/sites-enabled/000-default.conf /etc/apache2/sites-enabled/
+COPY ./resources/etc/apache2/conf-enabled/other-vhosts-access-log.conf /etc/apache2/conf-enabled/

--- a/digital-address-proxy/docker/resources/etc/apache2/conf-enabled/other-vhosts-access-log.conf
+++ b/digital-address-proxy/docker/resources/etc/apache2/conf-enabled/other-vhosts-access-log.conf
@@ -1,0 +1,3 @@
+# Define an access log for VirtualHosts that don't define their own logfile
+# CustomLog ${APACHE_LOG_DIR}/other_vhosts_access.log vhost_combined
+CustomLog "|/usr/bin/rotatelogs -l -n 60 /var/log/apache2/other_vhosts_access.log 86400" vhost_combined

--- a/digital-address-proxy/docker/resources/etc/apache2/sites-enabled/000-default.conf
+++ b/digital-address-proxy/docker/resources/etc/apache2/sites-enabled/000-default.conf
@@ -1,0 +1,31 @@
+<VirtualHost *:80>
+	# The ServerName directive sets the request scheme, hostname and port that
+	# the server uses to identify itself. This is used when creating
+	# redirection URLs. In the context of virtual hosts, the ServerName
+	# specifies what hostname must appear in the request's Host: header to
+	# match this virtual host. For the default virtual host (this file) this
+	# value is not decisive as it is used as a last resort host regardless.
+	# However, you must set it for any further virtual host explicitly.
+	#ServerName www.example.com
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	# ErrorLog ${APACHE_LOG_DIR}/error.log
+	ErrorLog "|/usr/bin/rotatelogs -l -n 60 /var/log/apache2/error.log 86400"
+	# CustomLog ${APACHE_LOG_DIR}/access.log combined
+	CustomLog "|/usr/bin/rotatelogs -l -n 60 /var/log/apache2/access.log 86400" combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+</VirtualHost>


### PR DESCRIPTION
apache 付属の `rotatelogs` コマンドを使ってログのローテーションを設定しました。

- `access.log`, `access.log.1` ... `access.log.59` というように1日ごとに連番でログファイルが作成されます。
- 60ファイル作成し、61日めになった際、最もタイムスタンプが古いファイルがtruncateされ、そのファイルに以降のログが追記されます。なので初回は一番最初二作成された `access.log` がtruncate対象になります。
- 以後、1日ごとに最も古いファイルがtruncateされ、そのファイルにログが追記されるようになります。

@lobin-z0x50 レビューをお願いします。