### PR TITLE
[DONT MERGE]rails-basic3.0.4を作成

### DIFF
--- a/rails-basic/Dockerfile
+++ b/rails-basic/Dockerfile
@@ -3,7 +3,7 @@ FROM neogenia/ruby:$RUBY_VERSION
 
 # install dependency packages
 RUN apt-get update && apt-get -y install \
-        libmysqld-dev \
+        default-libmysqlclient-dev \
         mysql-client \
         curl \
         unzip \
@@ -39,6 +39,3 @@ RUN gem install bundler:2.1.4
 RUN usermod -u 1000 www-data
 RUN usermod -s /bin/bash www-data
 
-# misc settings
-RUN usermod -u 1000 www-data
-RUN usermod -s /bin/bash www-data

--- a/rails-basic/Dockerfile
+++ b/rails-basic/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -L -O https://moji.or.jp/wp-content/ipafont/IPAexfont/${FONT_FILE}.zip 
 # install node.js, yarn (for webpacker) and some packages
 RUN curl -L 'https://dl.yarnpkg.com/debian/pubkey.gpg' | apt-key add - \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
- && curl -L 'https://deb.nodesource.com/setup_14.x' | bash - \
+ && curl -L 'https://deb.nodesource.com/setup_16.x' | bash - \
  && apt-get install -y nodejs yarn \
  && yarn global add typescript
 

--- a/rails-basic/Dockerfile
+++ b/rails-basic/Dockerfile
@@ -11,8 +11,26 @@ RUN apt-get update && apt-get -y install \
         #imagemagick libmagickwand-dev \
         monit
 
-# install headless chrome
-RUN apt-get install -y chromium-browser
+# install headless chrome \
+# NOTE: chromium-browserのdev（開発版）を使用する
+# 参考: https://uepon.hatenadiary.com/entry/2021/01/02/213113
+#
+# 理由:
+#   通常のchromium-browserを実行すると、snapを使用してchromiumをインストールする必要が出てくるため。
+#
+#   chromium-browserを実行すると以下のエラーが出てしまう
+#     Command '/usr/bin/chromium-browser' requires the chromium snap to be installed.
+#        Please install it with:
+#        snap install chromium \
+#   しかし、snapはsystemdやsnapdなどに依存し、Dockerコンテナ内で使うのは簡単ではないと考えられる。
+#
+#   また、以下を参考にapt-getするリポジトリを追加し、chromiumのインストールを試みたが、
+#   Ubuntu Focalのリポジトリにはchromiumが存在しないため、インストール不可能だった。
+#   https://askubuntu.com/questions/1511625/how-to-install-chromium-browser-without-snap-or-flatpak-in-ubuntu-24-04/1511626#1511626
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository ppa:saiarcot895/chromium-dev -y
+RUN apt-get update
+RUN apt-get install -y chromium-browser chromium-chromedriver
 
 # install Japanese fonts
 ARG FONT_FILE=IPAexfont00401

--- a/rails-basic/Dockerfile
+++ b/rails-basic/Dockerfile
@@ -12,10 +12,7 @@ RUN apt-get update && apt-get -y install \
         monit
 
 # install headless chrome
-RUN curl -L https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable
+RUN apt-get install -y chromium-browser
 
 # install Japanese fonts
 ARG FONT_FILE=IPAexfont00401

--- a/rails-basic/build.sh
+++ b/rails-basic/build.sh
@@ -14,7 +14,14 @@ IMAGE_NAME=neogenia/$(basename $SCRIPT_DIR)
 NAME_TAG=$IMAGE_NAME:$TAG
 echo building image "$NAME_TAG" ...
 
-(cd $SCRIPT_DIR; time docker build -t $NAME_TAG --build-arg RUBY_VERSION=$RUBY_VERSION .) \
+if docker buildx version >/dev/null 2>&1; then
+  echo "Using buildx (multi-arch build)"
+  DOCKER_BUILD_COMMAND_BASE="docker buildx build --platform linux/amd64,linux/arm64"
+else
+  echo "Warning: buildx not found. Unable to multi-arch build"
+  DOCKER_BUILD_COMMAND_BASE="docker build"
+fi
+(cd $SCRIPT_DIR; time $DOCKER_BUILD_COMMAND_BASE -t $NAME_TAG --build-arg RUBY_VERSION=$RUBY_VERSION --build-arg BUILD_OPTS=$2 .) \
 && cat <<GUIDE
 # build finished successfuly.
 # If you push image to DockerHub, use below command:

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic-20190612
+FROM ubuntu:focal-20250404
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/ruby/build.sh
+++ b/ruby/build.sh
@@ -14,7 +14,14 @@ IMAGE_NAME=neogenia/ruby
 NAME_TAG=$IMAGE_NAME:$TAG
 echo building image "$NAME_TAG" ...
 
-(cd $SCRIPT_DIR; time docker build -t $NAME_TAG --build-arg RUBY_VERSION=$RUBY_VERSION --build-arg BUILD_OPTS=$2 .) \
+if docker buildx version >/dev/null 2>&1; then
+  echo "Using buildx (multi-arch build)"
+  DOCKER_BUILD_COMMAND_BASE="docker buildx build --platform linux/amd64,linux/arm64"
+else
+  echo "Warning: buildx not found. Unable to multi-arch build"
+  DOCKER_BUILD_COMMAND_BASE="docker build"
+fi
+(cd $SCRIPT_DIR; time $DOCKER_BUILD_COMMAND_BASE -t $NAME_TAG --build-arg RUBY_VERSION=$RUBY_VERSION --build-arg BUILD_OPTS=$2 .) \
 && cat <<GUIDE
 # build finished successfuly.
 # If you push image to DockerHub, use below command:


### PR DESCRIPTION
https://github.com/neogenia-jp/al-websystem/pull/4258
の対応のため、rails-basic3.0.4を作成

51f67d00b4e5a0e5ab006e4061f5b426f3d4742f （rails-basic3.0.3を作成した当時のコミット）
からブランチを作っています。

## 理由一覧

- 51f67d00b4e5a0e5ab006e4061f5b426f3d4742f からブランチを作っている理由
現在のDockerfileではubuntu:noble-20250127 を使用しているが、このイメージではOpenSSL3を使っており、Ruby3.0.xはOpenSSL3に対応しておらずインストールできないため。
```
 > [linux/arm64 4/5] RUN gem install bundle:
0.250 ERROR:  While executing gem ... (Gem::Exception)
0.250     OpenSSL is not available. Install OpenSSL and rebuild Ruby (preferred) or use non-HTTPS sources
```

- ubuntu:bionic -> ubuntu:focalにした理由
Apple Silicon Mac環境にてnokogiriをインストールしようとした際に`GLIBC_2.29 not found`のエラーが出てしまう。ubuntu:focalであれば、このエラーを回避できるため。
