### PR TITLE
[DONT MERGE]rubyおよびrails-basicのdockerイメージの作成時、マルチプラットフォームでイメージを作成できるようにした

### DIFF
--- a/rails-basic/Dockerfile
+++ b/rails-basic/Dockerfile
@@ -12,10 +12,12 @@ RUN apt-get update && apt-get -y install \
         monit
 
 # install headless chrome
-RUN curl -L https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+# arm64版のChromeがないため、chromiumを使う
+# 参考: https://askubuntu.com/questions/1511625/how-to-install-chromium-browser-without-snap-or-flatpak-in-ubuntu-24-04/1511626#1511626
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository ppa:xtradeb/apps -y \
     && apt-get update \
-    && apt-get install -y google-chrome-stable
+    && apt-get install -y chromium
 
 # install Japanese fonts
 # TODO: `apt install -y fonts-ipafont` でいける？

--- a/rails-basic/build.sh
+++ b/rails-basic/build.sh
@@ -1,26 +1,75 @@
 #!/bin/bash
 #
 # Usage:
-#   ./build.sh <ruby_version> [tag]
+#   ./build.sh <ruby_version> [--push] [tag]
+#   --pushオプションはbuildxを使用している場合にのみ有効で、ビルド後にイメージをDockerHubにプッシュします。
+#   tagは省略した場合はruby_versionと同じになります。
 # Example:
+#   ./build.sh 2.7.0
+#   ./build.sh 2.7.0 --push
 #   ./build.sh 2.7.0 latest
+#   ./build.sh 2.7.0 --push latest
 #
 SCRIPT_DIR=${SCRIPT_DIR:-$(cd $(dirname $0) && pwd)}
 
 RUBY_VERSION=${1:-2.7.0}
-TAG=${2:-$RUBY_VERSION}
+
+# buildxを使えるか判定する
+ENABLE_BUILD_X=""
+if docker buildx version >/dev/null 2>&1; then
+  ENABLE_BUILD_X=true
+fi
+
+# 第1引数（Rubyバージョン）以降のコマンド引数を確認する
+# pushオプション以外はタグとして扱う。
+shift || true
+PUSH_FLAG=""
+TAG=""
+for arg in "$@"; do
+  if [[ "$arg" == "--push" && $ENABLE_BUILD_X ]]; then
+    PUSH_FLAG="--push"
+  else
+    if [[ -z "$TAG" ]]; then
+      TAG="$arg"
+    fi
+  fi
+done
+
+# タグが指定されない場合はRubyバージョンをタグにする。
+if [[ -z "$TAG" ]]; then
+  TAG="$RUBY_VERSION"
+fi
+
+# コマンド引数を確認する
+PUSH_FLAG=""
+for arg in "$@"; do
+  if [[ "$arg" == "--push" && $ENABLE_BUILD_X ]]; then
+    PUSH_FLAG="--push"
+  fi
+done
 
 IMAGE_NAME=neogenia/$(basename $SCRIPT_DIR)
 NAME_TAG=$IMAGE_NAME:$TAG
 echo building image "$NAME_TAG" ...
 
-(cd $SCRIPT_DIR; time docker build -t $NAME_TAG --build-arg RUBY_VERSION=$RUBY_VERSION .) \
-&& cat <<GUIDE
-# build finished successfuly.
+if [[ -n "$ENABLE_BUILD_X" ]]; then
+  echo "Using buildx (multi-arch build)"
+  DOCKER_BUILD_COMMAND_BASE="docker buildx build --platform linux/amd64,linux/arm64 $PUSH_FLAG"
+else
+  echo "Warning: buildx not found. Unable to multi-arch build"
+  DOCKER_BUILD_COMMAND_BASE="docker build"
+fi
+
+(cd $SCRIPT_DIR; time $DOCKER_BUILD_COMMAND_BASE -t $NAME_TAG --build-arg RUBY_VERSION=$RUBY_VERSION  .) \
+&& echo "# build finished successfuly."
+
+# 自動pushしない場合はpushコマンドの案内を表示する
+if [[ -z "$PUSH_FLAG" ]]; then
+  cat <<GUIDE
 # If you push image to DockerHub, use below command:
 
 docker login
 
 docker push $NAME_TAG
-
 GUIDE
+fi

--- a/rails-basic/build.sh
+++ b/rails-basic/build.sh
@@ -2,42 +2,20 @@
 #
 # Usage:
 #   ./build.sh <ruby_version> [--push] [tag]
-#   --pushオプションはbuildxを使用している場合にのみ有効で、ビルド後にイメージをDockerHubにプッシュします。
 #   tagは省略した場合はruby_versionと同じになります。
 # Example:
 #   ./build.sh 2.7.0
-#   ./build.sh 2.7.0 --push
 #   ./build.sh 2.7.0 latest
-#   ./build.sh 2.7.0 --push latest
 #
 SCRIPT_DIR=${SCRIPT_DIR:-$(cd $(dirname $0) && pwd)}
 
 RUBY_VERSION=${1:-2.7.0}
+TAG=${2:-$RUBY_VERSION}
 
 # buildxを使えるか判定する
 ENABLE_BUILD_X=""
 if docker buildx version >/dev/null 2>&1; then
   ENABLE_BUILD_X=true
-fi
-
-# 第1引数（Rubyバージョン）以降のコマンド引数を確認する
-# pushオプション以外はタグとして扱う。
-shift || true
-PUSH_FLAG=""
-TAG=""
-for arg in "$@"; do
-  if [[ "$arg" == "--push" && $ENABLE_BUILD_X ]]; then
-    PUSH_FLAG="--push"
-  else
-    if [[ -z "$TAG" ]]; then
-      TAG="$arg"
-    fi
-  fi
-done
-
-# タグが指定されない場合はRubyバージョンをタグにする。
-if [[ -z "$TAG" ]]; then
-  TAG="$RUBY_VERSION"
 fi
 
 IMAGE_NAME=neogenia/$(basename $SCRIPT_DIR)
@@ -46,22 +24,19 @@ echo building image "$NAME_TAG" ...
 
 if [[ -n "$ENABLE_BUILD_X" ]]; then
   echo "Using buildx (multi-arch build)"
-  DOCKER_BUILD_COMMAND_BASE="docker buildx build --platform linux/amd64,linux/arm64 $PUSH_FLAG"
+  DOCKER_BUILD_COMMAND_BASE="docker buildx build --platform linux/amd64,linux/arm64"
 else
   echo "Warning: buildx not found. Unable to multi-arch build"
   DOCKER_BUILD_COMMAND_BASE="docker build"
 fi
 
 (cd $SCRIPT_DIR; time $DOCKER_BUILD_COMMAND_BASE -t $NAME_TAG --build-arg RUBY_VERSION=$RUBY_VERSION  .) \
-&& echo "# build finished successfuly."
-
-# 自動pushしない場合はpushコマンドの案内を表示する
-if [[ -z "$PUSH_FLAG" ]]; then
-  cat <<GUIDE
+&& cat <<GUIDE
+# build finished successfuly.
 # If you push image to DockerHub, use below command:
 
 docker login
 
 docker push $NAME_TAG
+
 GUIDE
-fi

--- a/rails-basic/build.sh
+++ b/rails-basic/build.sh
@@ -40,14 +40,6 @@ if [[ -z "$TAG" ]]; then
   TAG="$RUBY_VERSION"
 fi
 
-# コマンド引数を確認する
-PUSH_FLAG=""
-for arg in "$@"; do
-  if [[ "$arg" == "--push" && $ENABLE_BUILD_X ]]; then
-    PUSH_FLAG="--push"
-  fi
-done
-
 IMAGE_NAME=neogenia/$(basename $SCRIPT_DIR)
 NAME_TAG=$IMAGE_NAME:$TAG
 echo building image "$NAME_TAG" ...

--- a/ruby/build.sh
+++ b/ruby/build.sh
@@ -1,26 +1,61 @@
 #!/bin/bash
 #
 # Usage:
-#   ./build.sh <ruby_version> [build_options]
+#   ./build.sh <ruby_version> [--push] [build_options...]
+#   --pushオプションはbuildxを使用している場合にのみ有効で、ビルド後にイメージをDockerHubにプッシュします。
 # Example:
 #   ./build.sh 2.7.1 --with-jemalloc
+#   ./build.sh 2.7.1 --push --with-jemalloc
 #
 SCRIPT_DIR=${SCRIPT_DIR:-$(cd $(dirname $0) && pwd)}
 
 RUBY_VERSION=${1:-2.6.3}
 TAG=$RUBY_VERSION
 
+# buildxを使えるか判定する
+ENABLE_BUILD_X=""
+if docker buildx version >/dev/null 2>&1; then
+  ENABLE_BUILD_X=true
+fi
+
+# 第1引数（Rubyバージョン）以降のコマンド引数を確認する
+shift || true
+PUSH_FLAG=""
+BUILD_OPTS=""
+for arg in "$@"; do
+  if [[ "$arg" == "--push" && $ENABLE_BUILD_X ]]; then
+    PUSH_FLAG="--push"
+  else
+    if [[ -z "$BUILD_OPTS" ]]; then
+      BUILD_OPTS="$arg"
+    else
+      BUILD_OPTS="$BUILD_OPTS $arg"
+    fi
+  fi
+done
+
 IMAGE_NAME=neogenia/ruby
 NAME_TAG=$IMAGE_NAME:$TAG
 echo building image "$NAME_TAG" ...
 
-(cd $SCRIPT_DIR; time docker build -t $NAME_TAG --build-arg RUBY_VERSION=$RUBY_VERSION --build-arg BUILD_OPTS=$2 .) \
-&& cat <<GUIDE
-# build finished successfuly.
+if [[ -n "$ENABLE_BUILD_X" ]]; then
+  echo "Using buildx (multi-arch build)"
+  DOCKER_BUILD_COMMAND_BASE="docker buildx build --platform linux/amd64,linux/arm64 $PUSH_FLAG"
+else
+  echo "Warning: buildx not found. Unable to multi-arch build"
+  DOCKER_BUILD_COMMAND_BASE="docker build"
+fi
+
+(cd $SCRIPT_DIR; time $DOCKER_BUILD_COMMAND_BASE -t $NAME_TAG --build-arg RUBY_VERSION=$RUBY_VERSION --build-arg BUILD_OPTS="$BUILD_OPTS" .) \
+&& echo "# build finished successfuly."
+
+# 自動pushしない場合はpushコマンドの案内を表示する
+if [[ -z "$PUSH_FLAG" ]]; then
+  cat <<GUIDE
 # If you push image to DockerHub, use below command:
 
 docker login
 
 docker push $NAME_TAG
-
 GUIDE
+fi

--- a/ruby/build.sh
+++ b/ruby/build.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 #
 # Usage:
-#   ./build.sh <ruby_version> [--push] [build_options...]
-#   --pushオプションはbuildxを使用している場合にのみ有効で、ビルド後にイメージをDockerHubにプッシュします。
+#   ./build.sh <ruby_version> [build_options...]
 # Example:
 #   ./build.sh 2.7.1 --with-jemalloc
-#   ./build.sh 2.7.1 --push --with-jemalloc
 #
 SCRIPT_DIR=${SCRIPT_DIR:-$(cd $(dirname $0) && pwd)}
 
@@ -18,44 +16,25 @@ if docker buildx version >/dev/null 2>&1; then
   ENABLE_BUILD_X=true
 fi
 
-# 第1引数（Rubyバージョン）以降のコマンド引数を確認する
-shift || true
-PUSH_FLAG=""
-BUILD_OPTS=""
-for arg in "$@"; do
-  if [[ "$arg" == "--push" && $ENABLE_BUILD_X ]]; then
-    PUSH_FLAG="--push"
-  else
-    if [[ -z "$BUILD_OPTS" ]]; then
-      BUILD_OPTS="$arg"
-    else
-      BUILD_OPTS="$BUILD_OPTS $arg"
-    fi
-  fi
-done
-
 IMAGE_NAME=neogenia/ruby
 NAME_TAG=$IMAGE_NAME:$TAG
 echo building image "$NAME_TAG" ...
 
 if [[ -n "$ENABLE_BUILD_X" ]]; then
   echo "Using buildx (multi-arch build)"
-  DOCKER_BUILD_COMMAND_BASE="docker buildx build --platform linux/amd64,linux/arm64 $PUSH_FLAG"
+  DOCKER_BUILD_COMMAND_BASE="docker buildx build --platform linux/amd64,linux/arm64"
 else
   echo "Warning: buildx not found. Unable to multi-arch build"
   DOCKER_BUILD_COMMAND_BASE="docker build"
 fi
 
-(cd $SCRIPT_DIR; time $DOCKER_BUILD_COMMAND_BASE -t $NAME_TAG --build-arg RUBY_VERSION=$RUBY_VERSION --build-arg BUILD_OPTS="$BUILD_OPTS" .) \
-&& echo "# build finished successfuly."
-
-# 自動pushしない場合はpushコマンドの案内を表示する
-if [[ -z "$PUSH_FLAG" ]]; then
-  cat <<GUIDE
+(cd $SCRIPT_DIR; time $DOCKER_BUILD_COMMAND_BASE -t $NAME_TAG --build-arg RUBY_VERSION=$RUBY_VERSION --build-arg BUILD_OPTS=$2 .) \
+&& cat <<GUIDE
+# build finished successfuly.
 # If you push image to DockerHub, use below command:
 
 docker login
 
 docker push $NAME_TAG
+
 GUIDE
-fi


### PR DESCRIPTION
@lobin-z0x50 
この修正でruby:3.4.9, rails-basic:3.4.9をマルチプラットフォームで作りました。
レビューをお願いします。

これで作ったrails-basicのイメージでL-OrderのRailsコンテナのイメージを書き換え、うまくいけば「DONT MERGE」を外す予定です。

## rubyイメージ
- 作成コマンド
```
cd ruby
./build.sh 3.4.9 --push
```
- docker hubにアップしたイメージ
https://hub.docker.com/layers/neogenia/ruby/3.4.9/images/sha256-7c53837a36a87886d39fedad85e1bee041ebad28d62e75d34e63caf38f58538a


## rails-basicイメージ
- 作成コマンド
```
cd rails-basic
./build.sh 3.4.9 --push
```

- docker hubにアップしたイメージ
https://hub.docker.com/layers/neogenia/rails-basic/3.4.9/images/sha256-e53e1650d2b7984589a081465bcc01aa94e249605fd9a70e24f4d4fb5f8a7703
