### PR TITLE
[DONT MERGE]mariadb-mroongaのビルドする際マルチプラットフォームでビルドできるようにした

### DIFF
--- a/mariadb-mroonga/build.sh
+++ b/mariadb-mroonga/build.sh
@@ -2,10 +2,18 @@
 #
 # Usage:
 #   ./build.sh <mariadb_version> [tag]
+#   tagは省略した場合はMariaDBバージョンになります。
 # Example:
+#   ./build.sh 10.8.2
 #   ./build.sh 10.8.2 latest
 #
 SCRIPT_DIR=${SCRIPT_DIR:-$(cd $(dirname $0) && pwd)}
+
+# buildxを使えるか判定する
+ENABLE_BUILD_X=""
+if docker buildx version >/dev/null 2>&1; then
+  ENABLE_BUILD_X=true
+fi
 
 MARIA_DB_VERSION=${1:-10.8.2}
 TAG=${2:-$MARIA_DB_VERSION}
@@ -14,7 +22,15 @@ IMAGE_NAME=neogenia/$(basename $SCRIPT_DIR)
 NAME_TAG=$IMAGE_NAME:$TAG
 echo building image "$NAME_TAG" ...
 
-(cd $SCRIPT_DIR; time docker build -t $NAME_TAG --build-arg MARIA_DB_VERSION=$MARIA_DB_VERSION .) \
+if [[ -n "$ENABLE_BUILD_X" ]]; then
+  echo "Using buildx (multi-arch build)"
+  DOCKER_BUILD_COMMAND_BASE="docker buildx build --platform linux/amd64,linux/arm64"
+else
+  echo "Warning: buildx not found. Unable to multi-arch build"
+  DOCKER_BUILD_COMMAND_BASE="docker build"
+fi
+
+(cd $SCRIPT_DIR; time $DOCKER_BUILD_COMMAND_BASE -t $NAME_TAG --build-arg MARIA_DB_VERSION=$MARIA_DB_VERSION .) \
 && cat <<GUIDE
 # build finished successfuly.
 # If you push image to DockerHub, use below command:


### PR DESCRIPTION
@lobin-z0x50 
この修正でmariadb-mroonga:10.11.18 をマルチプラットフォームで作りました。

レビューをお願いします。
これで作ったmariadb-mroongaのイメージでL-Orderのdbコンテナのイメージを書き換え、うまくいけば「DONT MERGE」を外す予定です。

## rubyイメージ
- 作成コマンド
```
cd mariadb-mroonga
./build.sh 10.11.18
```

https://hub.docker.com/layers/neogenia/mariadb-mroonga/10.11.18/images/sha256-e4e6e8b231748054b95d919266c544c97003c38f2bb154153f139bcf25c210d1